### PR TITLE
chore: Restrict Python versions to 3.9-3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.x', 'pypy-3.8' ]
+        python-version: ['3.9', '3.10', '3.11', 'pypy-3.9' ]
     name: Python ${{ matrix.python-version }} pipeline
     steps:
       - uses: actions/checkout@v3

--- a/poetry.lock
+++ b/poetry.lock
@@ -636,9 +636,10 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [metadata]
-lock-version = "1.1"
-python-versions = "^3.8"
-content-hash = "546e1db09bdfeddbb13f958cb75768a57798db07c58304fb45f6b35de8432787"
+lock-version = "2.0"
+python-versions = "^3.9,<3.12"
+content-hash = "68c885e97a8271a21fb27a3db4aa33bbd75339fc9d12cd5c36702e8d6f1315da"
+
 
 [metadata.files]
 attrs = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["agile", "jira", "birthdays"]
 tibian = "tibian.main:main"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9,<3.12"
 jira = "^3.1.1"
 requests = "^2.27.1"
 python-dateutil = "^2.8.2"


### PR DESCRIPTION
Python 3.8 is out of life in half a year, and restricts some dependency upgrades / changes right now. Therefore, we remove it. Python 3.12 has some breaking changes we tackle soon, but breaks the CI right now. Therefore, we also exclude it.