### PR TITLE
chore: make dev dependencies optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install package
         run: |
           pip install poetry
-          poetry install
+          poetry install --with dev
       - name: Check style of package
         run: poetry run -- pre-commit run --all
       - name: Run tests

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ For details about configuration, visit section `Configuration`.
 
 To install the project, run one of the following command::
 
-    poetry install --no-dev # or
+    poetry install # or
     pip install tibian
 
 Later one is preferred, as it installs the project with the same versions
@@ -72,7 +72,7 @@ We use poetry_ for the development of tibian. You can install it with the follow
 
 To install all development dependencies, run::
 
-    poetry install
+    poetry install --with dev
 
 Afterwards, you have all dependencies (including dev dependencies) installed in a virtualenv, and are able to develop.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -794,4 +794,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.12"
-content-hash = "9aec3e29550028e250babd2b614277fbed72f5941d48dcaf98284be3d6f35b81"
+content-hash = "7e3c7b52fa3a1aad828bda67926b66f69c8577c88344b71a05ee55f76f310675"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,9 @@ requests = "^2.27.1"
 python-dateutil = "^2.8.2"
 PyYAML = "^6.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev]
+optional=true
+[tool.poetry.group.dev.dependencies]
 pre-commit = "^3.6.2"
 pytest = "^7.1.1"
 pytest-cov = "^3.0.0"


### PR DESCRIPTION
Previosly, development dependencies where always installed. Now, this dependency grouped is marked 'optional' so it is only installed if explicitly requested.

This reduces the number of dependencies for tibian