### PR TITLE
chore: Allow Python newer than 3.11 again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', 'pypy-3.9' ]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.x', 'pypy-3.9' ]
     name: Python ${{ matrix.python-version }} pipeline
     steps:
       - uses: actions/checkout@v3

--- a/poetry.lock
+++ b/poetry.lock
@@ -793,5 +793,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9,<3.12"
-content-hash = "7e3c7b52fa3a1aad828bda67926b66f69c8577c88344b71a05ee55f76f310675"
+python-versions = "^3.9"
+content-hash = "580f54648923362379a3490ec275a7396430f52781212177650ae711e6de4333"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["agile", "jira", "birthdays"]
 tibian = "tibian.main:main"
 
 [tool.poetry.dependencies]
-python = "^3.9,<3.12"
+python = "^3.9"
 jira = "^3.1.1"
 requests = "^2.27.1"
 python-dateutil = "^2.8.2"


### PR DESCRIPTION
As we updated the development setup with pre-commit before, we can now also handle Python 3.12 and newer.

We therefore loosen the restriction of <3.12 for the package, and activate it in CI for testing.