### PR TITLE
fix: Use correct way of poetry dynamic versioning

### DIFF
--- a/.github/workflows/artifact_release.yml
+++ b/.github/workflows/artifact_release.yml
@@ -19,7 +19,8 @@ jobs:
           python-version: '3.x'
       - name: Build package
         run: |
-          pip install poetry poetry-dynamic-versioning
+          pip install poetry
+          poetry self add "poetry-dynamic-versioning[plugin]"
           poetry build
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ pytest-mock = "^3.7.0"
 freezegun = "^1.2.1"
 requests-mock = "^1.9.3"
 
+[tool.poetry-dynamic-versioning]
+enable = true
+
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
The way and activation of dynamic versioning changed in poetry, therefore we update it to the proper way.