### PR TITLE
chore: Remove 'pypy' interpreter from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.x', 'pypy-3.9' ]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.x']
     name: Python ${{ matrix.python-version }} pipeline
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I don't see any real point in executing the script with pypy JIT, but it consumes overproportionally CI time. Therefore, we remove it from the CI tests, as long as we are not aware of a problem which only occurs in pypy (which is unlikely, as we don't use numeric libs at all)