### PR TITLE
fix: Name build artifacts on release correctly

### DIFF
--- a/.github/workflows/artifact_release.yml
+++ b/.github/workflows/artifact_release.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
+          name: dist
           path: dist
 
   create-pypi-release:


### PR DESCRIPTION
By default, the name is 'artifact', which does not match the expected naming schema of the rest of the pipeline. This commit explicitly sets the name to dist, which should fix the issue.