### PR TITLE
fix: Remove named download on GH release

### DIFF
--- a/.github/workflows/artifact_release.yml
+++ b/.github/workflows/artifact_release.yml
@@ -47,8 +47,6 @@ jobs:
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v2
-        with:
-          path: artifacts
       - name: Extract tag from gitref
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}


### PR DESCRIPTION
This was forgotten in #22, which is now fixed