### PR TITLE
feat: add taiga as ticket source

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,6 +6,12 @@ sources:
   auth:
     username: 'username'
     password: 'password'
+- type: 'taiga'
+  name: 'my-taiga'
+  project: 42
+  url: 'https://taiga.example.com'
+  auth:
+    token: my-token
 
 destinations:
 - type: 'stdout'

--- a/src/tibian/config.py
+++ b/src/tibian/config.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 import yaml
 
 from tibian.sources.jira import JiraSource
+from tibian.sources.taiga import TaigaSource
 from tibian.targets.stdout import StdoutTarget
 from tibian.targets.teams import TeamsTarget
 import tibian.vars
@@ -12,7 +13,7 @@ _DEFAULT_CONFIG_PATH = tibian.vars.get_std_config_filepath()
 
 
 class TibianConfig(BaseModel):
-    sources: list[JiraSource]
+    sources: list[Union[JiraSource, TaigaSource]]
     destinations: list[Union[StdoutTarget, TeamsTarget]]
 
 

--- a/src/tibian/sources/taiga.py
+++ b/src/tibian/sources/taiga.py
@@ -1,0 +1,63 @@
+from typing import List, Any, Literal, Union
+
+import dateutil.parser
+from pydantic import BaseModel, HttpUrl, SecretStr
+import requests
+
+from tibian.sources.ticketsource import TicketSource
+from tibian.tickets import Ticket
+
+TAIGA_API_PATH = "/api/v1"
+
+
+class TaigaAuth(BaseModel):
+    token: SecretStr
+
+
+class TaigaSource(TicketSource):
+    type: Literal["taiga"] = "taiga"
+    url: HttpUrl
+    project: int
+    auth: TaigaAuth
+
+    def get_open_tickets(self) -> List[Ticket]:
+        open_issues = []
+        search_url = self._get_taiga_search_url()
+        content = self._request_issues(search_url)
+
+        for story in content:
+            ticket = self._extract_ticket_from_story(story)
+            open_issues.append(ticket)
+
+        return open_issues
+
+    def _get_taiga_search_url(self) -> str:
+        return f"{self.url}{TAIGA_API_PATH.strip('/')}/userstories"
+
+    def _request_issues(self, search_url: str) -> list[dict[str, Any]]:
+        query_params: dict[str, Union[float, str]] = {
+            "project": self.project,
+            "status__is_closed": "false",
+        }
+        headers = {
+            "Authorization": f"Bearer {self.auth.token.get_secret_value()}",
+            "x-disable-pagination": "True",
+        }
+        response = requests.get(
+            search_url,
+            params=query_params,
+            headers=headers,
+            timeout=5,
+        )
+        response.raise_for_status()
+        content: list[dict[str, Any]] = response.json()
+        return content
+
+    def _extract_ticket_from_story(self, story: dict[str, Any]) -> Ticket:
+        key = str(story["ref"])
+        title = story["subject"]
+        status = story["status_extra_info"]["name"]
+        created = dateutil.parser.parse(story["created_date"]).date()
+
+        ticket = Ticket(key, title, status, created)
+        return ticket

--- a/tests/sources/test_taiga.py
+++ b/tests/sources/test_taiga.py
@@ -1,0 +1,56 @@
+import datetime
+import pytest
+from pydantic import SecretStr, HttpUrl
+from tibian.sources.taiga import TaigaSource, TaigaAuth
+from tibian.tickets import Ticket
+
+
+@pytest.fixture
+def taiga_source():
+    return TaigaSource(
+        name="taiga-source",
+        url=HttpUrl("https://taiga.example.com"),
+        project=42,
+        auth=TaigaAuth(token=SecretStr("mock_token")),
+    )
+
+
+def test_get_open_tickets(taiga_source, requests_mock):
+    mock_stories = [
+        {
+            "ref": 101,
+            "subject": "Fix login issue",
+            "status_extra_info": {"name": "In Progress"},
+            "created_date": "2023-01-05T07:54:22Z",
+        },
+        {
+            "ref": 102,
+            "subject": "Add new feature",
+            "status_extra_info": {"name": "Open"},
+            "created_date": "2023-03-18T16:12:34Z",
+        },
+    ]
+
+    requests_mock.get("https://taiga.example.com/api/v1/userstories", json=mock_stories)
+
+    tickets = taiga_source.get_open_tickets()
+    assert len(requests_mock.request_history) == 1
+    last_request = requests_mock.last_request
+
+    assert last_request.headers["Authorization"] == "Bearer mock_token"
+    assert last_request.qs == {"project": ["42"], "status__is_closed": ["false"]}
+
+    assert tickets == [
+        Ticket(
+            name="101",
+            title="Fix login issue",
+            status="In Progress",
+            creation_date=datetime.date(2023, 1, 5),
+        ),
+        Ticket(
+            name="102",
+            title="Add new feature",
+            status="Open",
+            creation_date=datetime.date(2023, 3, 18),
+        ),
+    ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import pytest
 
 import tibian.config as tc
 from tibian.sources.jira import JiraSource
+from tibian.sources.taiga import TaigaSource
 from tibian.targets.stdout import StdoutTarget
 from tibian.targets.teams import TeamsTarget
 
@@ -17,8 +18,9 @@ def test_load_example_config(_example_config_file):
     config = tc.load_config(_example_config_file)
 
     assert config.sources is not None
-    assert len(config.sources) == 1
+    assert len(config.sources) == 2
     assert isinstance(config.sources[0], JiraSource)
+    assert isinstance(config.sources[1], TaigaSource)
 
     assert config.destinations is not None
     assert len(config.destinations) == 2


### PR DESCRIPTION
This change adds Taiga (https://taiga.io/), an open-source project management tool, as another source for open tickets.

Closes #26